### PR TITLE
[MT-7777] support RTL language

### DIFF
--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionView.swift
@@ -34,12 +34,15 @@ struct W3WPanelSuggestionView: View {
       }
       
       VStack(alignment: .leading) {
-        
-        W3WTextView((suggestion.suggestion.words ?? "----.----.----").w3w.style(font: scheme?.styles?.font?.body).withSlashes())
-          .lineLimit(1)
-          .allowsTightening(true)
-          .minimumScaleFactor(0.5)
-
+        W3WTextView((suggestion.suggestion.words ?? "----.----.----")
+          .w3w
+          .style(font: scheme?.styles?.font?.body)
+          .withSlashes(language: suggestion.suggestion.language)
+        )
+        .lineLimit(1)
+        .allowsTightening(true)
+        .minimumScaleFactor(0.5)
+          
         HStack {
           if suggestion.suggestion.country?.code == "ZZ" {
             W3WTextView((suggestion.suggestion.nearestPlace ?? "middle of the ocean 🐟").w3w.style(color: scheme?.colors?.secondary, font: scheme?.styles?.font?.footnote).withSlashes(color: .clear, font: scheme?.styles?.font?.body))
@@ -62,6 +65,7 @@ struct W3WPanelSuggestionView: View {
       
     }
     .contentShape(Rectangle())
+    .layoutDirection(for: suggestion.suggestion.language)
     .onTapGesture {
       onTap()
     }
@@ -80,8 +84,6 @@ struct W3WPanelSuggestionView: View {
     Divider()
   }
 }
-
-
 
 #Preview {
   let s1 = W3WBaseSuggestion(words: "xxx.xxx.xxx", nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))

--- a/Sources/W3WSwiftPresenters/Panel/Views/W3WPanelScreen.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/W3WPanelScreen.swift
@@ -43,6 +43,7 @@ public struct W3WPanelScreen<ViewModel: W3WPanelViewModelProtocol>: View {
       }
     }
     .background(scheme?.colors?.background?.current.suColor)
+    .layoutDirectionFromAppearance()
   }
 }
 


### PR DESCRIPTION
## [MT-7777] feat(W3WPanelSuggestionView & W3WTextView): support RTL layout direction

This PR updates `W3WPanelSuggestionView` & `W3WTextView` to fully support right-to-left (RTL) languages.  
The screen now respects the layout direction based on the current language setting selected by the user (e.g., Arabic, Hebrew).

### Changes
- Adjusted layout and UI elements in `W3WPanelSuggestionView` & `W3WTextView` to dynamically follow the `LayoutDirection` from environment/language.

### Notes
- No changes to business logic — layout adjustments only.

[MT-7778]: https://what3words.atlassian.net/browse/MT-7788

[MT-7777]: https://what3words.atlassian.net/browse/MT-7777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ