### PR TITLE
[MT-7890] Fix missing 'near' keyword in OCR bottomsheet

### DIFF
--- a/Sources/W3WSwiftPresenters/Panel/ViewModel/W3WPanelViewModel.swift
+++ b/Sources/W3WSwiftPresenters/Panel/ViewModel/W3WPanelViewModel.swift
@@ -12,14 +12,18 @@ import W3WSwiftThemes
 
 /// A panel view that contains list items
 public class W3WPanelViewModel: W3WPanelViewModelProtocol, W3WEventSubscriberProtocol {
+  
   public var subscriptions = W3WEventsSubscriptions()
-
+  
   /// the items in the list
   @Published public var items = W3WPanelItemList(items: [])
-
+  
   /// the scheme to use
   @Published public var scheme: W3WScheme?
   
+  @Published public var language: W3WLanguage?
+  
+  public var translations: W3WTranslationsProtocol?
   /// input events
   public var input = W3WEvent<W3WPanelInputEvent>()
   
@@ -31,7 +35,8 @@ public class W3WPanelViewModel: W3WPanelViewModelProtocol, W3WEventSubscriberPro
   /// - Parameters:
   ///     - scheme: the scheme to use for he views
   ///     - language: the language in use, used for writting direction
-  public init(scheme: W3WLive<W3WScheme?>? = nil, language: W3WLive<W3WLanguage?>? = nil) {
+  public init(scheme: W3WLive<W3WScheme?>? = nil, language: W3WLive<W3WLanguage?>? = nil, translations: W3WTranslationsProtocol?) {
+    self.translations = translations
     subscribe(to: input) { [weak self] event in
       self?.handle(event: event)
     }
@@ -45,17 +50,15 @@ public class W3WPanelViewModel: W3WPanelViewModelProtocol, W3WEventSubscriberPro
     }
   }
   
-  
   /// handle a language change
   func handle(language: W3WLanguage?) {
+    self.language = language
   }
-  
   
   /// handle a scheme change
   func handle(scheme: W3WScheme?) {
     self.scheme = scheme
   }
-  
   
   /// handle in input event
   func handle(event: W3WPanelInputEvent) {

--- a/Sources/W3WSwiftPresenters/Panel/ViewModel/W3WPanelViewModelProtocol.swift
+++ b/Sources/W3WSwiftPresenters/Panel/ViewModel/W3WPanelViewModelProtocol.swift
@@ -24,5 +24,8 @@ public protocol W3WPanelViewModelProtocol: ObservableObject {
   
   /// the scheme to use
   var scheme: W3WScheme? { get set }
-
+  
+  var language: W3WLanguage? { get set }
+  
+  var translations: W3WTranslationsProtocol? { get set }
 }

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelRowView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelRowView.swift
@@ -44,7 +44,7 @@ struct W3WPanelRowView<ViewModel: W3WPanelViewModelProtocol>: View {
       W3WPanelTappableRow(icon: image, text: text, scheme: scheme)
       
     case .suggestions(let suggestions):
-      W3WPanelSuggestionsView(suggestions: suggestions, scheme: scheme)
+      W3WPanelSuggestionsView(suggestions: suggestions, scheme: scheme, language: viewModel.language, translations: viewModel.translations)
       
     default:
       Text("?")

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionView.swift
@@ -13,18 +13,22 @@ import W3WSwiftThemes
 
 struct W3WPanelSuggestionView: View {
   @State private var cancellable: AnyCancellable?
- 
+  
   let suggestion: W3WSelectableSuggestion
+  
+  let language: W3WLanguage?
+  
+  let translations: W3WTranslationsProtocol?
   
   var showDivider: Bool = true
   
   let scheme: W3WScheme?
   
   let onTap: () -> Void
-
+  
   @State var selected: Bool?
-
-
+  
+  
   var body: some View {
     HStack(alignment: .firstTextBaseline, spacing: 0) {
       if let selected {
@@ -52,7 +56,7 @@ struct W3WPanelSuggestionView: View {
           .lineLimit(1)
           .allowsTightening(true)
           .minimumScaleFactor(0.5)
-            
+          
           HStack {
             W3WTextView(nearestPlace
               .w3w
@@ -74,7 +78,7 @@ struct W3WPanelSuggestionView: View {
                   color: W3WColor.w3wLabelsQuaternary,
                   font: scheme?.styles?.font?.footnote
                 ) ?? "".w3w)
-              .padding(.trailing)
+            .padding(.trailing)
           }
         }
       }
@@ -105,9 +109,15 @@ struct W3WPanelSuggestionView: View {
 // MARK: - Helpers
 private extension W3WPanelSuggestionView {
   var nearestPlace: String {
-    // If there is no nearest place, just return blank
-    return suggestion.suggestion.nearestPlace ?? ""
+    // currently, display 'near' keyword in English language only. Should improve later after we update our localisations for all languages
+    guard let placeName = suggestion.suggestion.nearestPlace else { return "" }
+    if let language, language.code == "en", let translations {
+      let nearString = translations.get(id: "near")
+      return String(format: "%@ %@", nearString, placeName)
+    }
+    return placeName
   }
+  
   
   func circleIcon(isSelected: Bool) -> some View {
     if isSelected {
@@ -128,17 +138,17 @@ private extension W3WPanelSuggestionView {
   let s3 = W3WBaseSuggestion(words: "zz.zz.zz", country: W3WBaseCountry(code: "ZZ"), nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
   let s4 = W3WBaseSuggestion(words: "reallyreally.longverylong.threewordaddress", nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
 
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s4, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s4, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
 }

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionsView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionsView.swift
@@ -17,6 +17,10 @@ struct W3WPanelSuggestionsView: View {
   var suggestions: W3WSelectableSuggestions
   
   @State var scheme: W3WScheme?
+  
+  @State var language: W3WLanguage?
+  
+  let translations: W3WTranslationsProtocol?
 
   @State private var refresh = false
   
@@ -28,8 +32,10 @@ struct W3WPanelSuggestionsView: View {
         ForEach(suggestions.suggestions) { selectableSuggestion in
           W3WPanelSuggestionView(
             suggestion: selectableSuggestion,
+            language: language,
+            translations: translations,
             showDivider: selectableSuggestion.id != suggestions.suggestions.last?.id,
-            scheme: .standard) {
+            scheme: scheme) {
             if let s = selectableSuggestion.selected.value {
               selectableSuggestion.selected.send(!s)
             } else {
@@ -67,5 +73,5 @@ struct W3WPanelSuggestionsView: View {
   suggestions.add(suggestion: s3, selected: false)
   suggestions.add(suggestion: s4, selected: true)
 
-  return W3WPanelSuggestionsView(suggestions: suggestions)
+  return W3WPanelSuggestionsView(suggestions: suggestions, translations: nil)
 }

--- a/Sources/W3WSwiftPresenters/Panel/Views/W3WPanelScreen.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/W3WPanelScreen.swift
@@ -67,7 +67,7 @@ public struct W3WPanelScreen<ViewModel: W3WPanelViewModelProtocol>: View {
   let s3 = W3WBaseSuggestion(words: "zz.zz.zz", country: W3WBaseCountry(code: "ZZ"), nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
   let s4 = W3WBaseSuggestion(words: "reallyreally.longverylong.threewordaddress", nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
 
-  var items = W3WPanelViewModel(scheme: W3WLive<W3WScheme?>(.w3w), language: W3WLive<W3WLanguage?>(W3WBaseLanguage(locale: "en")))
+  var items = W3WPanelViewModel(scheme: W3WLive<W3WScheme?>(.w3w), language: W3WLive<W3WLanguage?>(W3WBaseLanguage(locale: "en")), translations: nil)
 
   W3WPanelScreen(viewModel: items, scheme: .w3w)
 }


### PR DESCRIPTION
Changes: 
- Pass in `language` and `translations` to add `near` keyword next to near place name in bottomsheet

Note: Only display `near` keyword in English language for now. 