### PR TITLE
MT-7925 Update theme for OCR Bottomsheet

### DIFF
--- a/Sources/W3WSwiftPresenters/Panel/ViewModel/W3WPanelViewModel.swift
+++ b/Sources/W3WSwiftPresenters/Panel/ViewModel/W3WPanelViewModel.swift
@@ -18,8 +18,7 @@ public class W3WPanelViewModel: W3WPanelViewModelProtocol, W3WEventSubscriberPro
   /// the items in the list
   @Published public var items = W3WPanelItemList(items: [])
   
-  /// the scheme to use
-  @Published public var scheme: W3WScheme?
+  @Published public var theme: W3WTheme?
   
   @Published public var language: W3WLanguage?
   
@@ -35,14 +34,15 @@ public class W3WPanelViewModel: W3WPanelViewModelProtocol, W3WEventSubscriberPro
   /// - Parameters:
   ///     - scheme: the scheme to use for he views
   ///     - language: the language in use, used for writting direction
-  public init(scheme: W3WLive<W3WScheme?>? = nil, language: W3WLive<W3WLanguage?>? = nil, translations: W3WTranslationsProtocol?) {
+  public init(theme: W3WLive<W3WTheme?>? = nil, language: W3WLive<W3WLanguage?>? = nil, translations: W3WTranslationsProtocol?) {
     self.translations = translations
+    self.theme = theme?.value
     subscribe(to: input) { [weak self] event in
       self?.handle(event: event)
     }
     
-    subscribe(to: scheme) { [weak self] scheme in
-      self?.handle(scheme: scheme)
+    subscribe(to: theme) { [weak self] theme in
+      self?.theme = theme
     }
     
     subscribe(to: language) { [weak self] language in
@@ -56,8 +56,8 @@ public class W3WPanelViewModel: W3WPanelViewModelProtocol, W3WEventSubscriberPro
   }
   
   /// handle a scheme change
-  func handle(scheme: W3WScheme?) {
-    self.scheme = scheme
+  func handle(theme: W3WTheme?) {
+    self.theme = theme
   }
   
   /// handle in input event

--- a/Sources/W3WSwiftPresenters/Panel/ViewModel/W3WPanelViewModelProtocol.swift
+++ b/Sources/W3WSwiftPresenters/Panel/ViewModel/W3WPanelViewModelProtocol.swift
@@ -22,8 +22,7 @@ public protocol W3WPanelViewModelProtocol: ObservableObject {
   /// output events
   var output: W3WEvent<W3WPanelOutputEvent> { get set }
   
-  /// the scheme to use
-  var scheme: W3WScheme? { get set }
+  var theme: W3WTheme? { get set }
   
   var language: W3WLanguage? { get set }
   

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelActionItemView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelActionItemView.swift
@@ -17,7 +17,7 @@ struct W3WPanelActionItemView: View {
   var icon: W3WImage
   var text: W3WLive<W3WString>
   var button: W3WButtonData
-  @State var scheme: W3WScheme?
+  @State var theme: W3WTheme?
 
   @State var liveText = NSAttributedString()
 
@@ -25,6 +25,7 @@ struct W3WPanelActionItemView: View {
     HStack {
       Image(uiImage: icon.get())
       Text(liveText.string)
+        .scheme(theme?.labelScheme(grade: .secondary, fontStyle: .subheadline, weight: .regular))
       Spacer()
       Button(button.title ?? "", action: { button.onTap() })
     }

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelButtonsAndTitleView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelButtonsAndTitleView.swift
@@ -18,21 +18,16 @@ struct W3WPanelButtonsAndTitleView: View {
   
   var text: W3WLive<W3WString>
 
-  var scheme: W3WScheme?
+  @State var theme: W3WTheme?
 
   @State var liveText = W3WString()
 
   var body: some View {
     HStack(spacing: W3WPadding.none.value) {
       if liveText.asString() != "" {
-        W3WTextView(liveText
-          .style(
-            color: W3WColor(
-              light: W3WCoreColor.black,
-              dark: W3WCoreColor.white
-            )
-          )
-        )
+        // TODO: - Should fix highlighted text
+        Text(liveText.asString())
+          .scheme(theme?.labelScheme(grade: .primary, fontStyle: .body, weight: .regular).with(foreground: W3WColor.w3wLabelsPrimaryBlackInverse))
         Spacer()
       }
       HStack {
@@ -50,10 +45,10 @@ struct W3WPanelButtonsAndTitleView: View {
               .padding(.vertical, W3WPadding.extraMedium.value)
               .padding(.leading, W3WPadding.light.value)
               .padding(.trailing, W3WPadding.medium.value)
-              .foregroundColor(scheme?.colors?.highlight?.foreground?.current.suColor)
+              .foregroundColor(theme?.labelsSecondary?.suColor)
               .background((button.highlight == .primary)
-                          ? scheme?.colors?.secondaryBackground?.current.suColor
-                          : W3WColor.w3wFillsSenary.suColor)
+                          ? theme?.fillsQuaternary?.suColor
+                          : theme?.fillsSenary?.suColor)
               .clipShape(.capsule)
             }
           }
@@ -62,7 +57,7 @@ struct W3WPanelButtonsAndTitleView: View {
     }
     .padding(.bottom, W3WPadding.light.value)
     .padding(.horizontal, W3WPadding.bold.value)
-    .background(scheme?.colors?.background?.current.suColor)
+    .background(theme?.systemBackgroundBasePrimary?.suColor)
     .onAppear { // Subscribe to the text changes
       cancellable = text
         .sink { content in

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelButtonsView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelButtonsView.swift
@@ -15,17 +15,16 @@ struct W3WPanelButtonsView: View {
 
   @State var buttons: [W3WButtonData]
 
-  var scheme: W3WScheme?
+  @State var theme: W3WTheme?
 
   var body: some View {
     HStack {
       ForEach(buttons) { button in
-        _Button(button: button, scheme: scheme)
+        _Button(button: button, theme: theme)
       }
     }
     .padding(.bottom, W3WPadding.light.value)
     .padding(.horizontal, W3WPadding.bold.value)
-    .background(scheme?.colors?.background?.current.suColor)
   }
 }
 
@@ -33,23 +32,24 @@ private extension W3WPanelButtonsView {
   struct _Button: View {
     @ObservedObject var button: W3WButtonData
     
-    var scheme: W3WScheme?
+    @State var theme: W3WTheme?
     
     // Consider using a preference key to track the biggest width
     private let minButtonWidth: CGFloat = 93
     
     var body: some View {
       if let title = button.title {
+        //TODO: - (Kaley) Can replace this with W3WSUButton (?)
         Button(action: button.onTap) {
           Text(title)
             .padding(.vertical, W3WPadding.extraMedium.value)
             .padding(.horizontal, W3WPadding.bold.value)
             .frame(minWidth: minButtonWidth)
-            .foregroundColor(scheme?.colors?.highlight?.foreground?.current.suColor)
+            .foregroundColor(theme?.labelsSecondary?.suColor)
             .background(
               button.highlight == .primary
-              ? scheme?.colors?.secondaryBackground?.current.suColor
-              : W3WColor.w3wFillsSenary.suColor
+              ? theme?.fillsQuaternary?.suColor
+              : theme?.fillsSenary?.suColor
             )
             .clipShape(.rect(cornerRadius: buttonCornerRadius))
         }
@@ -57,21 +57,12 @@ private extension W3WPanelButtonsView {
     }
     
     private var buttonCornerRadius: CGFloat {
-      scheme?.styles?.cornerRadius?.value ?? 8
+      W3WPadding.light.value
     }
   }
 }
 
 #Preview {
-  let scheme = W3WLive<W3WScheme?>(
-    W3WScheme(colors: W3WColors(
-      foreground: .white,
-      background: .lightBlue,
-      secondaryBackground: .blue
-    ))
-  )
-
-  
   W3WPanelButtonsView(
     buttons: [
       W3WButtonData(icon: .badge, title: "titleA", onTap: { }),

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelHeadingView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelHeadingView.swift
@@ -13,7 +13,7 @@ struct W3WPanelHeadingView<ViewModel: W3WPanelViewModelProtocol>: View {
   
   var title: W3WString
 
-  var scheme: W3WScheme?
+  @State var theme: W3WTheme?
 
   // view model
   @ObservedObject var viewModel: ViewModel
@@ -21,21 +21,18 @@ struct W3WPanelHeadingView<ViewModel: W3WPanelViewModelProtocol>: View {
   var body: some View {
     HStack {
       Spacer()
-      W3WTextView(
-        title.style(
-          color: scheme?.colors?.header?.foreground,
-          font: scheme?.styles?.fonts?.headline
-        ),
-        separator: false
-      )
+      Text(title.asString())
+        .scheme(textScheme)
       .multilineTextAlignment(.center)
       .frame(alignment: .center)
-      .background(scheme?.colors?.background?.suColor)
       .padding(W3WPadding.medium.value)
       Spacer()
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .listRowBackground(scheme?.colors?.secondaryBackground?.suColor)
     .animation(.easeInOut(duration: 0.1))
+  }
+  
+  var textScheme: W3WScheme? {
+    theme?.labelScheme(grade: .tertiary, fontStyle: .body, weight: .bold)
   }
 }

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelMessageView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelMessageView.swift
@@ -16,7 +16,7 @@ struct W3WPanelMessageView<ViewModel: W3WPanelViewModelProtocol>: View {
 
   var message: W3WLive<W3WString>
 
-  var scheme: W3WScheme? = .w3w
+  @State var theme: W3WTheme?
   
   // view model
   @ObservedObject var viewModel: ViewModel
@@ -26,14 +26,11 @@ struct W3WPanelMessageView<ViewModel: W3WPanelViewModelProtocol>: View {
 
   var body: some View {
     HStack {
-      W3WTextView(liveText, separator: false)
-        .foregroundColor(scheme?.colors?.secondary?.suColor)
-        .background(scheme?.colors?.background?.suColor)
+      Text(message.value.string.string)
+        .scheme(theme?.labelScheme(grade: .tertiary, fontStyle: .body, weight: .bold))
       Spacer()
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    //.background(scheme?.colors?.secondaryBackground?.suColor)
-    .listRowBackground(scheme?.colors?.secondaryBackground?.suColor)
     .animation(.easeInOut(duration: 0.1))
     .onAppear {
       // Subscribe to the CurrentValueSubject and update the countText on change

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelPrimaryActionView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelPrimaryActionView.swift
@@ -14,13 +14,15 @@ import W3WSwiftDesign
 struct W3WPanelPrimaryActionView: View {
   let button: W3WButtonData
   
+  @State var theme: W3WTheme?
+  
   var body: some View {
     Button(action: button.onTap) {
       Text(button.title ?? "")
         .padding(.vertical, W3WPadding.bold.value)
         .frame(maxWidth: .infinity)
-        .foregroundColor(W3WColor.w3wLabelsPrimary.suColor)
-        .background(W3WColor.w3wFillsSecondary.suColor)
+        .foregroundColor(W3WColor.w3wLabelsPrimaryWhite.suColor)
+        .background(theme?.fillsSecondary?.suColor)
         .clipShape(.rect(cornerRadius: 8))
     }
     .padding(.bottom, W3WPadding.light.value)

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelRowView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelRowView.swift
@@ -16,35 +16,32 @@ struct W3WPanelRowView<ViewModel: W3WPanelViewModelProtocol>: View {
   
   let item: W3WPanelItem
   
-  var scheme: W3WScheme?
-
-  
   var body: some View {
     switch item {
       
     case .heading(let text):
-      W3WPanelHeadingView(title: text.value, scheme: scheme, viewModel: viewModel)
+      W3WPanelHeadingView(title: text.value, theme: viewModel.theme, viewModel: viewModel)
       
     case .message(let message):
-      W3WPanelMessageView(message: message, scheme: scheme, viewModel: viewModel)
+      W3WPanelMessageView(message: message, theme: viewModel.theme, viewModel: viewModel)
       
     case .actionItem(icon: let icon, text: let text, let button):
-      W3WPanelActionItemView(icon: icon, text: text, button: button, scheme: scheme)
+      W3WPanelActionItemView(icon: icon, text: text, button: button, theme: viewModel.theme)
       
     case .button(let button):
-      W3WPanelPrimaryActionView(button: button)
+      W3WPanelPrimaryActionView(button: button, theme: viewModel.theme)
       
     case .buttons(let buttons):
-      W3WPanelButtonsView(buttons: buttons, scheme: scheme)
+      W3WPanelButtonsView(buttons: buttons, theme: viewModel.theme)
       
     case .buttonsAndTitle(let buttons, text: let text):
-      W3WPanelButtonsAndTitleView(buttons: buttons, text: text, scheme: scheme)
-      
-    case .tappableRow(icon: let image, text: let text):
-      W3WPanelTappableRow(icon: image, text: text, scheme: scheme)
+      W3WPanelButtonsAndTitleView(buttons: buttons, text: text, theme: viewModel.theme)
       
     case .suggestions(let suggestions):
-      W3WPanelSuggestionsView(suggestions: suggestions, scheme: scheme, language: viewModel.language, translations: viewModel.translations)
+      W3WPanelSuggestionsView(suggestions: suggestions,
+                              theme: viewModel.theme,
+                              language: viewModel.language,
+                              translations: viewModel.translations)
       
     default:
       Text("?")

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionView.swift
@@ -22,7 +22,7 @@ struct W3WPanelSuggestionView: View {
   
   var showDivider: Bool = true
   
-  let scheme: W3WScheme?
+  @State var theme: W3WTheme?
   
   let onTap: () -> Void
   
@@ -40,45 +40,28 @@ struct W3WPanelSuggestionView: View {
       }
       
       W3WTextView("".w3w
-        .style(font: scheme?.styles?.font?.body)
+        .style(font: theme?.labelScheme(grade: .primary, fontStyle: .body, weight: .medium).styles?.font)
         .withSlashes()
       )
       
       HStack(alignment: .firstTextBaseline, spacing: 0) {
         VStack(alignment: .leading, spacing: W3WPadding.fine.value) {
-          W3WTextView((suggestion.suggestion.words ?? "----.----.----")
-            .w3w
-            .style(
-              color: W3WColor.w3wLabelsTertiary,
-              font: scheme?.styles?.font?.body
-            )
-          )
+          Text(suggestion.suggestion.words ?? "----.----.----")
+            .scheme(wordsScheme)
           .lineLimit(1)
           .allowsTightening(true)
           .minimumScaleFactor(0.5)
           
           HStack {
-            W3WTextView(nearestPlace
-              .w3w
-              .style(
-                color: W3WColor.w3wLabelsQuaternary,
-                font: scheme?.styles?.font?.footnote
-              )
-            )
+            Text(nearestPlace)
+              .scheme(nearestPlaceScheme)
             .lineLimit(1)
-            .allowsTightening(true)
-            .minimumScaleFactor(0.5)
+            .allowsTightening(false)
             
             Spacer()
             
-            W3WTextView(
-              suggestion.suggestion.distanceToFocus?.description
-                .w3w
-                .style(
-                  color: W3WColor.w3wLabelsQuaternary,
-                  font: scheme?.styles?.font?.footnote
-                ) ?? "".w3w)
-            .padding(.trailing)
+            Text(suggestion.suggestion.distanceToFocus?.description ?? "")
+              .scheme(distanceScheme)
           }
         }
       }
@@ -132,23 +115,37 @@ private extension W3WPanelSuggestionView {
   }
 }
 
+private extension W3WPanelSuggestionView {
+  var nearestPlaceScheme: W3WScheme? {
+    theme?.labelScheme(grade: .quaternary, fontStyle: .footnote, weight: .regular)
+  }
+  
+  var distanceScheme: W3WScheme? {
+    theme?.labelScheme(grade: .quaternary, fontStyle: .footnote, weight: .bold)
+  }
+  
+  var wordsScheme: W3WScheme? {
+    theme?.labelScheme(grade: .tertiary, fontStyle: .body, weight: .semibold)
+  }
+}
+
 #Preview {
   let s1 = W3WBaseSuggestion(words: "xxx.xxx.xxx", nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
   let s2 = W3WBaseSuggestion(words: "yyyy.yyyy.yyyy", nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
   let s3 = W3WBaseSuggestion(words: "zz.zz.zz", country: W3WBaseCountry(code: "ZZ"), nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
   let s4 = W3WBaseSuggestion(words: "reallyreally.longverylong.threewordaddress", nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
 
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s4, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
-  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil, scheme: .standard) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s4, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s1, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s2, selected: false), language: nil, translations: nil) { print("x") }
+  W3WPanelSuggestionView(suggestion: W3WSelectableSuggestion(suggestion: s3, selected: false), language: nil, translations: nil) { print("x") }
 }

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionsView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionsView.swift
@@ -16,8 +16,8 @@ struct W3WPanelSuggestionsView: View {
 
   @ObservedObject var suggestions: W3WSelectableSuggestions
   
-  @State var scheme: W3WScheme?
-  
+  @State var theme: W3WTheme?
+
   @State var language: W3WLanguage?
   
   let translations: W3WTranslationsProtocol?
@@ -35,7 +35,7 @@ struct W3WPanelSuggestionsView: View {
             language: language,
             translations: translations,
             showDivider: selectableSuggestion.id != suggestions.suggestions.last?.id,
-            scheme: scheme) {
+            theme: theme) {
             if let s = selectableSuggestion.selected.value {
               selectableSuggestion.selected.send(!s)
             } else {

--- a/Sources/W3WSwiftPresenters/Panel/Views/W3WPanelScreen.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/W3WPanelScreen.swift
@@ -12,26 +12,22 @@ import W3WSwiftThemes
 public struct W3WPanelScreen<ViewModel: W3WPanelViewModelProtocol>: View {
   // main view model
   @ObservedObject var viewModel: ViewModel
-
-  var scheme: W3WScheme?
   
-  public init(viewModel: ViewModel, scheme: W3WScheme? = nil) {
+  public init(viewModel: ViewModel) {
     self.viewModel = viewModel
-    self.scheme = scheme
   }
-  
   
   public var body: some View {
     VStack(spacing: 0) {
       header
       ScrollView {
         ForEach(viewModel.items.listNormal, id: \.id) { item in
-          W3WPanelRowView(viewModel: viewModel, item: item, scheme: scheme)
+          W3WPanelRowView(viewModel: viewModel, item: item)
         }
       }
       footer
     }
-    .background(scheme?.colors?.background?.current.suColor)
+    .background(viewModel.theme?.systemBackgroundBasePrimary?.suColor)
   }
   
   @ViewBuilder
@@ -39,8 +35,7 @@ public struct W3WPanelScreen<ViewModel: W3WPanelViewModelProtocol>: View {
     if let header = viewModel.items.getHeader() {
       W3WPanelRowView(
         viewModel: viewModel,
-        item: header,
-        scheme: scheme
+        item: header
       )
     }
   }
@@ -51,10 +46,9 @@ public struct W3WPanelScreen<ViewModel: W3WPanelViewModelProtocol>: View {
       VStack {
         Divider()
           .shadow(radius: 1, x: 0, y: 1)
-        W3WPanelRowView(viewModel: viewModel, item: viewModel.items.list[0], scheme: scheme)
+        W3WPanelRowView(viewModel: viewModel, item: viewModel.items.list[0])
       }
       .padding(.top, 16)
-      .background(scheme?.colors?.background?.current.suColor)
     }
   }
 }
@@ -65,7 +59,7 @@ public struct W3WPanelScreen<ViewModel: W3WPanelViewModelProtocol>: View {
   let s3 = W3WBaseSuggestion(words: "zz.zz.zz", country: W3WBaseCountry(code: "ZZ"), nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
   let s4 = W3WBaseSuggestion(words: "reallyreally.longverylong.threewordaddress", nearestPlace: "place place placey", distanceToFocus: W3WBaseDistance(meters: 1234.0))
 
-  var items = W3WPanelViewModel(scheme: W3WLive<W3WScheme?>(.w3w), language: W3WLive<W3WLanguage?>(W3WBaseLanguage(locale: "en")), translations: nil)
+  var items = W3WPanelViewModel(theme: nil, language: W3WLive<W3WLanguage?>(W3WBaseLanguage(locale: "en")), translations: nil)
 
-  W3WPanelScreen(viewModel: items, scheme: .w3w)
+  W3WPanelScreen(viewModel: items)
 }


### PR DESCRIPTION
Changes: 
- Apply correct theme for OCR Bottomsheet (using W3WTheme and W3WScheme) 
- Set not autotightening for text (near ABC) 