### PR TITLE
Release w3w-swift-presenters v1.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9f08de626cf02f8abe37ab69994dd020b43cf4885a88e8753d40fbb7cff6a3f0",
+  "originHash" : "809d1cd4965c5210daf9a7d06954a9b7ba7bae76f122a2b08db52156caca25c5",
   "pins" : [
     {
       "identity" : "w3w-swift-core",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/what3words/w3w-swift-core.git",
       "state" : {
-        "revision" : "7fe8769bfbe105bcf3b05f42aeb8833673780ec1",
-        "version" : "1.1.4"
+        "branch" : "staging",
+        "revision" : "1e38676bf065d6c3411895fe2c47bab04c56bba0"
       }
     },
     {
@@ -15,14 +15,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/what3words/w3w-swift-design.git",
       "state" : {
-        "revision" : "2495f4f80c1a872264211ac937f71d15d8516490",
-        "version" : "1.1.0"
+        "branch" : "staging",
+        "revision" : "093a87c7998ae4833eaa0df9e44b80d6a52b19b7"
       }
     },
     {
       "identity" : "w3w-swift-design-swiftui",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:what3words/w3w-swift-design-swiftui.git",
+      "location" : "https://github.com/what3words/w3w-swift-design-swiftui.git",
       "state" : {
         "branch" : "dev/v5.6.0",
         "revision" : "cfab6fefc5b39d5437937c18ec3d7e137d2c8ae8"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c7b79a0f78a4181271d0018403be0724b63749db6737d234a3939a48bc90297",
+  "originHash" : "f09aba5e28f3c606eafe41e4d7610a8adfdad5906227ef998e6d4f666c6abdaf",
   "pins" : [
     {
       "identity" : "w3w-swift-core",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:what3words/w3w-swift-design-swiftui.git",
       "state" : {
-        "revision" : "73b23041dadf77fa7ceb1278fbfe2eee2ed31616",
-        "version" : "1.2.0"
+        "branch" : "dev/v5.4.0",
+        "revision" : "d8392250e8b4ba30fb44301f5a46b5b985bde8b2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "ca96af316a5f503eb4c5393a77a1cbfbd14f7eb6ff0eae4f5adab6a496c5b940",
+  "originHash" : "e7f9d8f2d43b1b8b1748328aad69c6db144c64a846a5d3e2bd18113dafebe252",
   "pins" : [
     {
       "identity" : "w3w-swift-core",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/what3words/w3w-swift-core.git",
       "state" : {
-        "branch" : "staging",
-        "revision" : "1e38676bf065d6c3411895fe2c47bab04c56bba0"
+        "revision" : "2725169511ecd21ba30d4613c5e3c5b79bd405f4",
+        "version" : "1.3.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/what3words/w3w-swift-design.git",
       "state" : {
-        "branch" : "staging",
-        "revision" : "093a87c7998ae4833eaa0df9e44b80d6a52b19b7"
+        "revision" : "701ba8136c66f67f0fc3c2778f825ac12d0e0100",
+        "version" : "1.3.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/what3words/w3w-swift-design-swiftui.git",
       "state" : {
-        "branch" : "dev/v5.6.0",
-        "revision" : "cfab6fefc5b39d5437937c18ec3d7e137d2c8ae8"
+        "revision" : "73067b5216c188359a38cd915752764e3e84e754",
+        "version" : "1.5.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/what3words/w3w-swift-themes.git",
       "state" : {
-        "branch" : "staging",
-        "revision" : "9371b0319c86a4432421f6c6100c2c2eb01740dc"
+        "revision" : "bf6fd677b3ce16e81952ffea3627ffa534e5c5c7",
+        "version" : "1.5.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "809d1cd4965c5210daf9a7d06954a9b7ba7bae76f122a2b08db52156caca25c5",
+  "originHash" : "ca96af316a5f503eb4c5393a77a1cbfbd14f7eb6ff0eae4f5adab6a496c5b940",
   "pins" : [
     {
       "identity" : "w3w-swift-core",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/what3words/w3w-swift-themes.git",
       "state" : {
-        "revision" : "86035dcf1cf9ce5be7dc0a1a761fb5561b795b2c",
-        "version" : "1.3.0"
+        "branch" : "staging",
+        "revision" : "9371b0319c86a4432421f6c6100c2c2eb01740dc"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f09aba5e28f3c606eafe41e4d7610a8adfdad5906227ef998e6d4f666c6abdaf",
+  "originHash" : "9f08de626cf02f8abe37ab69994dd020b43cf4885a88e8753d40fbb7cff6a3f0",
   "pins" : [
     {
       "identity" : "w3w-swift-core",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:what3words/w3w-swift-design-swiftui.git",
       "state" : {
-        "branch" : "dev/v5.4.0",
-        "revision" : "d8392250e8b4ba30fb44301f5a46b5b985bde8b2"
+        "branch" : "dev/v5.6.0",
+        "revision" : "cfab6fefc5b39d5437937c18ec3d7e137d2c8ae8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,10 @@ let package = Package(
     ],
     
     dependencies: [
-      .package(url: "https://github.com/what3words/w3w-swift-core.git", branch: "staging"),
-      .package(url: "https://github.com/what3words/w3w-swift-themes.git", branch: "staging"),
-      .package(url: "https://github.com/what3words/w3w-swift-design.git", branch: "staging"),
-      .package(url: "https://github.com/what3words/w3w-swift-design-swiftui.git", branch: "dev/v5.6.0"),
+      .package(url: "https://github.com/what3words/w3w-swift-core.git", "1.3.0"..<"2.0.0"),
+      .package(url: "https://github.com/what3words/w3w-swift-themes.git", "1.5.0"..<"2.0.0"),
+      .package(url: "https://github.com/what3words/w3w-swift-design.git", "1.3.0"..<"2.0.0"),
+      .package(url: "https://github.com/what3words/w3w-swift-design-swiftui.git", "1.5.0"..<"2.0.0"),
     ],
     
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
       .package(url: "https://github.com/what3words/w3w-swift-core.git", "1.0.0" ..< "2.0.0"),
       .package(url: "https://github.com/what3words/w3w-swift-themes.git", "1.0.0" ..< "2.0.0"),
       .package(url: "https://github.com/what3words/w3w-swift-design.git", "1.0.0" ..< "2.0.0"),
-      .package(url: "git@github.com:what3words/w3w-swift-design-swiftui.git", "1.0.0" ..< "2.0.0")
+      .package(url: "git@github.com:what3words/w3w-swift-design-swiftui.git", branch: "dev/v5.4.0")
     ],
     
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -15,17 +15,16 @@ let package = Package(
     ],
     
     dependencies: [
-      .package(url: "https://github.com/what3words/w3w-swift-core.git", "1.0.0" ..< "2.0.0"),
+      .package(url: "https://github.com/what3words/w3w-swift-core.git", branch: "staging"),
       .package(url: "https://github.com/what3words/w3w-swift-themes.git", "1.0.0" ..< "2.0.0"),
-      .package(url: "https://github.com/what3words/w3w-swift-design.git", "1.0.0" ..< "2.0.0"),
-      .package(url: "git@github.com:what3words/w3w-swift-design-swiftui.git", branch: "dev/v5.6.0")
+      .package(url: "https://github.com/what3words/w3w-swift-design.git", branch: "staging"),
+      .package(url: "https://github.com/what3words/w3w-swift-design-swiftui.git", branch: "dev/v5.6.0"),
     ],
     
     targets: [
         .target(
           name: "W3WSwiftPresenters",
           dependencies: [
-            //.product(name: "W3WSwiftApi", package: "w3w-swift-wrapper"),
             .product(name: "W3WSwiftCore", package: "w3w-swift-core"),
             .product(name: "W3WSwiftThemes", package: "w3w-swift-themes"),
             .product(name: "W3WSwiftDesign", package: "w3w-swift-design"),

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     
     dependencies: [
       .package(url: "https://github.com/what3words/w3w-swift-core.git", branch: "staging"),
-      .package(url: "https://github.com/what3words/w3w-swift-themes.git", "1.0.0" ..< "2.0.0"),
+      .package(url: "https://github.com/what3words/w3w-swift-themes.git", branch: "staging"),
       .package(url: "https://github.com/what3words/w3w-swift-design.git", branch: "staging"),
       .package(url: "https://github.com/what3words/w3w-swift-design-swiftui.git", branch: "dev/v5.6.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
       .package(url: "https://github.com/what3words/w3w-swift-core.git", "1.0.0" ..< "2.0.0"),
       .package(url: "https://github.com/what3words/w3w-swift-themes.git", "1.0.0" ..< "2.0.0"),
       .package(url: "https://github.com/what3words/w3w-swift-design.git", "1.0.0" ..< "2.0.0"),
-      .package(url: "git@github.com:what3words/w3w-swift-design-swiftui.git", branch: "dev/v5.4.0")
+      .package(url: "git@github.com:what3words/w3w-swift-design-swiftui.git", branch: "dev/v5.6.0")
     ],
     
     targets: [

--- a/Sources/W3WSwiftPresenters/ImagePicker/Events/W3WImagePickerOutputEvent.swift
+++ b/Sources/W3WSwiftPresenters/ImagePicker/Events/W3WImagePickerOutputEvent.swift
@@ -7,11 +7,12 @@
 
 import CoreGraphics
 import W3WSwiftCore
-
+import Photos
 
 public enum W3WImagePickerOutputEvent {
   
   case image(CGImage)
+  case imageAndAsset(CGImage, PHAsset)
   case dismiss
   case error(W3WError)
   

--- a/Sources/W3WSwiftPresenters/ImagePicker/Views/W3WImagePickerViewController.swift
+++ b/Sources/W3WSwiftPresenters/ImagePicker/Views/W3WImagePickerViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import MobileCoreServices
 import UniformTypeIdentifiers
 import Photos
+import W3WSwiftThemes
 
 public class W3WImagePickerViewController: UIImagePickerController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
   
@@ -49,9 +50,12 @@ public class W3WImagePickerViewController: UIImagePickerController, UIImagePicke
 
   
   public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-    guard
-      let image = info[.originalImage] as? UIImage,
-      let cgImage = image.cgImage else { return }
+    guard let image = info[.originalImage] as? UIImage else { return }
+    // The output event carries a `CGImage`, which has no orientation flag. If we forwarded
+    // `image.cgImage` directly, a portrait photo (EXIF `.right`) would arrive at consumers
+    // as raw sideways pixels and display rotated 90°. Bake the EXIF orientation into the
+    // pixel data first so the emitted `CGImage` is already upright.
+    guard let cgImage = image.normalizedOrientation().cgImage else { return }
     hasPickedImage = true
     if let asset = info[.phAsset] as? PHAsset {
       viewModel?.output.send(.imageAndAsset(cgImage, asset))
@@ -60,9 +64,9 @@ public class W3WImagePickerViewController: UIImagePickerController, UIImagePicke
     }
   }
 
-  
+
   public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
     viewModel?.output.send(.dismiss)
   }
-  
+
 }

--- a/Sources/W3WSwiftPresenters/ImagePicker/Views/W3WImagePickerViewController.swift
+++ b/Sources/W3WSwiftPresenters/ImagePicker/Views/W3WImagePickerViewController.swift
@@ -8,8 +8,7 @@
 import UIKit
 import MobileCoreServices
 import UniformTypeIdentifiers
-
-
+import Photos
 
 public class W3WImagePickerViewController: UIImagePickerController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
   
@@ -54,7 +53,11 @@ public class W3WImagePickerViewController: UIImagePickerController, UIImagePicke
       let image = info[.originalImage] as? UIImage,
       let cgImage = image.cgImage else { return }
     hasPickedImage = true
-    viewModel?.output.send(.image(cgImage))
+    if let asset = info[.phAsset] as? PHAsset {
+      viewModel?.output.send(.imageAndAsset(cgImage, asset))
+    } else {
+      viewModel?.output.send(.image(cgImage))
+    }
   }
 
   

--- a/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionView.swift
+++ b/Sources/W3WSwiftPresenters/Panel/Views/RowViews/W3WPanelSuggestionView.swift
@@ -83,13 +83,7 @@ struct W3WPanelSuggestionView: View {
 // MARK: - Helpers
 private extension W3WPanelSuggestionView {
   var nearestPlace: String {
-    // currently, display 'near' keyword in English language only. Should improve later after we update our localisations for all languages
-    guard let placeName = suggestion.nearestPlace else { return "" }
-    if let language, language.code == "en", let translations {
-      let nearString = translations.get(id: "near")
-      return String(format: "%@ %@", nearString, placeName)
-    }
-    return placeName
+    return suggestion.nearestPlace ?? ""
   }
   
   


### PR DESCRIPTION
## Summary

Promotes `staging` into `main` (final leg of dev → staging → main) to cut release **v1.2.0** (minor bump from v1.1.0).

### What's included
- Normalize picker image orientation; `W3WImagePicker` output adds `imageAndAsset`.
- Removed "near" out of OCR result screen; panel suggestion view tweak.
- Pinned deps off branches: core → `"1.3.0"..<"2.0.0"`, themes → `"1.5.0"..<"2.0.0"`, design → `"1.3.0"..<"2.0.0"`, design-swiftui → `"1.5.0"..<"2.0.0"`.